### PR TITLE
Avoid implicit declaration of shm_open() and shm_unlink()

### DIFF
--- a/shared_numpy/posixshmem.c
+++ b/shared_numpy/posixshmem.c
@@ -7,6 +7,9 @@ posixshmem - A Python extension that provides shm_open() and shm_unlink()
 #include <Python.h>
 #include "structmember.h"
 
+int shm_open(const char *, int, ...);
+int shm_unlink(const char *);
+
 // for shm_open() and shm_unlink()
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>


### PR DESCRIPTION
Attempt to fix #3.

On MacOS, this module can fail with:
```
shared_numpy/posixshmem.c:52:14: error: implicit declaration of function 'shm_open' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        fd = shm_open(name, flags, mode);
             ^
shared_numpy/posixshmem.c:91:14: error: implicit declaration of function 'shm_unlink' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        rv = shm_unlink(name);
             ^
```

So I added prototype for `shm_open()` and `shm_unlink()` to fix this. Tested on MacOS Mojave and Ubuntu 20.04 LTS.

Can you take a look @dillonalaird ? Thanks for checking by